### PR TITLE
Correct dir paths and uninstall target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ project(augyang C)
 # include custom Modules
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/CMakeModules/")
 
+include(GNUInstallDirs)
 include(ExternalProject)
 include(SourceFormat)
 
@@ -248,7 +249,8 @@ add_custom_command(TARGET augyang
 #
 # installation
 #
-
+install(TARGETS srds_augeas DESTINATION ${CMAKE_INSTALL_LIBDIR}/sysrepo/plugins)
+install(TARGETS augyang ay_startup DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(DIRECTORY "${PROJECT_SOURCE_DIR}/modules/" DESTINATION ${YANG_MODULE_DIR})
 foreach(YANG IN LISTS YANG_LIST)
     list(APPEND YANG_FILES_LIST ${CMAKE_CURRENT_BINARY_DIR}/${YANG}.yang)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -285,3 +285,6 @@ add_custom_target(cclean
         COMMAND find . -iname '*cmake*' -not -name CMakeLists.txt -not -path './CMakeModules*' -exec rm -rf {} +
         COMMAND rm -rf Makefile Doxyfile
         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+# uninstall
+add_custom_target(uninstall "${CMAKE_COMMAND}" -P "${CMAKE_MODULE_PATH}/uninstall.cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,7 +192,7 @@ include_directories(${SYSREPO_INCLUDE_DIRS})
 
 # augeas external project
 set(AUGEAS_DOWNLOAD_COMMAND git clone https://github.com/hercules-team/augeas "${AUGEAS_DIR}" 2> /dev/null || true)
-set(GNULIB_DOWNLOAD_COMMAND git clone https://git.savannah.gnu.org/git/gnulib.git "${GNULIB_DIR}" 2> /dev/null || true)
+set(GNULIB_DOWNLOAD_COMMAND git clone https://github.com/coreutils/gnulib.git "${GNULIB_DIR}" 2> /dev/null || true)
 ExternalProject_Add(augeas_ext
         PREFIX ${AUGEAS_PREFIX}
         DOWNLOAD_COMMAND ${AUGEAS_DOWNLOAD_COMMAND} && ${GNULIB_DOWNLOAD_COMMAND}

--- a/CMakeModules/uninstall.cmake
+++ b/CMakeModules/uninstall.cmake
@@ -1,0 +1,25 @@
+set(MANIFEST "${CMAKE_CURRENT_BINARY_DIR}/install_manifest.txt")
+
+if(NOT EXISTS ${MANIFEST})
+    message(FATAL_ERROR "Cannot find install manifest: ${MANIFEST}")
+endif()
+
+file(STRINGS ${MANIFEST} files)
+foreach(file ${files})
+    if(EXISTS ${file} OR IS_SYMLINK ${file})
+        message(STATUS "Removing: ${file}")
+
+        execute_process(COMMAND rm -f ${file}
+                RESULT_VARIABLE result
+                OUTPUT_QUIET
+                ERROR_VARIABLE stderr
+                ERROR_STRIP_TRAILING_WHITESPACE
+        )
+
+        if(NOT ${result} EQUAL 0)
+            message(FATAL_ERROR "${stderr}")
+        endif()
+    else()
+        message(STATUS "Does-not-exist: ${file}")
+    endif()
+endforeach()


### PR DESCRIPTION
- include GNUInstallDirs module to install the binaries, yang models and plugin in correct locations 
- use gnulib's public github mirror as git.savannah.gnu.org often times out or resets connection
- add uninstall target (copied from sysrepo project)